### PR TITLE
Fixed --json flag

### DIFF
--- a/main.go
+++ b/main.go
@@ -84,7 +84,7 @@ func main() {
 
 	// Render the template to stdout.
 
-	fmt.Println(template.Render(context))
+	fmt.Print(template.Render(context))
 }
 
 func fatalError(err error) {


### PR DESCRIPTION
Was getting an error even when --json wasn't passed (i.e., using the default echo example). Also removed the trailing newline just to keep things clean. `gofmt` may have cleaned up a few things also... 
